### PR TITLE
[#6] 검색창 기능 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,7 @@
 		"@typescript-eslint/triple-slash-reference": "off",
 		"react/react-in-jsx-scope": "off",
 		"no-var": "error",
-		"no-unused-vars": "error",
+		"no-unused-vars": ["error", { "args": "none" }],
 		"eqeqeq": "error",
 		"no-console": ["error", { "allow": ["warn", "error"] }]
 	}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,6 @@
 		"no-var": "error",
 		"no-unused-vars": ["error", { "args": "none" }],
 		"eqeqeq": "error",
-		"no-console": ["error", { "allow": ["warn", "error"] }]
+		"no-console": ["error", { "allow": ["info", "warn", "error"] }]
 	}
 }

--- a/src/components/feature/SickSearch/SickSearchAutoComplete/index.tsx
+++ b/src/components/feature/SickSearch/SickSearchAutoComplete/index.tsx
@@ -7,16 +7,18 @@ import * as S from './styled';
 type Props = {
 	sickKeyword: string;
 	recommendSicks: Sick[];
+	currentAutoCompleteIndex: number;
+	autoCompleteRef: React.MutableRefObject<HTMLUListElement>;
 };
 
 const SickSearchAutoComplete = (props: Props) => {
 	return (
 		<>
 			{props.sickKeyword && (
-				<S.Container>
+				<S.Container ref={props.autoCompleteRef}>
 					{isNotEmptyArray(props.recommendSicks) ? (
 						<>
-							<S.AutoCompleteItemWrapper>
+							<S.AutoCompleteItemWrapper isFocused={props.currentAutoCompleteIndex === -1}>
 								🔍
 								<S.TextWrapper>
 									<S.HightLightText>{props.sickKeyword}</S.HightLightText>
@@ -24,9 +26,9 @@ const SickSearchAutoComplete = (props: Props) => {
 							</S.AutoCompleteItemWrapper>
 
 							<S.Caption>추천 검색어</S.Caption>
-							{props.recommendSicks.map((recommendSick) => {
+							{props.recommendSicks.map((recommendSick, index) => {
 								return (
-									<S.AutoCompleteItemWrapper key={recommendSick.sickCd}>
+									<S.AutoCompleteItemWrapper key={recommendSick.sickCd} isFocused={props.currentAutoCompleteIndex === index}>
 										🔍
 										<S.TextWrapper>
 											{splitTargetRegardlessOfStringCase(recommendSick.sickNm, props.sickKeyword).map(

--- a/src/components/feature/SickSearch/SickSearchAutoComplete/index.tsx
+++ b/src/components/feature/SickSearch/SickSearchAutoComplete/index.tsx
@@ -16,6 +16,13 @@ const SickSearchAutoComplete = (props: Props) => {
 				<S.Container>
 					{isNotEmptyArray(props.recommendSicks) ? (
 						<>
+							<S.AutoCompleteItemWrapper>
+								🔍
+								<S.TextWrapper>
+									<S.HightLightText>{props.sickKeyword}</S.HightLightText>
+								</S.TextWrapper>
+							</S.AutoCompleteItemWrapper>
+
 							<S.Caption>추천 검색어</S.Caption>
 							{props.recommendSicks.map((recommendSick) => {
 								return (

--- a/src/components/feature/SickSearch/SickSearchAutoComplete/index.tsx
+++ b/src/components/feature/SickSearch/SickSearchAutoComplete/index.tsx
@@ -12,31 +12,37 @@ type Props = {
 const SickSearchAutoComplete = (props: Props) => {
 	return (
 		<>
-			{props.sickKeyword && isNotEmptyArray(props.recommendSicks) && (
+			{props.sickKeyword && (
 				<S.Container>
-					<S.Caption>추천 검색어</S.Caption>
-					{props.recommendSicks.map((recommendSick) => {
-						return (
-							<S.AutoCompleteItemWrapper key={recommendSick.sickCd}>
-								🔍
-								<S.TextWrapper>
-									{splitTargetRegardlessOfStringCase(recommendSick.sickNm, props.sickKeyword).map(
-										(splitedItem, index, splitedItems) => {
-											if (splitedItems.length - 1 === index) {
-												return <React.Fragment key={index}>{splitedItem}</React.Fragment>;
-											}
-											return (
-												<React.Fragment key={index}>
-													{splitedItem}
-													<S.HightLightText>{props.sickKeyword.toUpperCase()}</S.HightLightText>
-												</React.Fragment>
-											);
-										},
-									)}
-								</S.TextWrapper>
-							</S.AutoCompleteItemWrapper>
-						);
-					})}
+					{isNotEmptyArray(props.recommendSicks) ? (
+						<>
+							<S.Caption>추천 검색어</S.Caption>
+							{props.recommendSicks.map((recommendSick) => {
+								return (
+									<S.AutoCompleteItemWrapper key={recommendSick.sickCd}>
+										🔍
+										<S.TextWrapper>
+											{splitTargetRegardlessOfStringCase(recommendSick.sickNm, props.sickKeyword).map(
+												(splitedItem, index, splitedItems) => {
+													if (splitedItems.length - 1 === index) {
+														return <React.Fragment key={index}>{splitedItem}</React.Fragment>;
+													}
+													return (
+														<React.Fragment key={index}>
+															{splitedItem}
+															<S.HightLightText>{props.sickKeyword.toUpperCase()}</S.HightLightText>
+														</React.Fragment>
+													);
+												},
+											)}
+										</S.TextWrapper>
+									</S.AutoCompleteItemWrapper>
+								);
+							})}
+						</>
+					) : (
+						<S.AutoCompleteItemWrapper>🔍 "{props.sickKeyword}"와(과) 연관된 추천 검색어가 없습니다.</S.AutoCompleteItemWrapper>
+					)}
 				</S.Container>
 			)}
 		</>

--- a/src/components/feature/SickSearch/SickSearchAutoComplete/index.tsx
+++ b/src/components/feature/SickSearch/SickSearchAutoComplete/index.tsx
@@ -1,25 +1,45 @@
+import React from 'react';
 import { Sick } from '@src/types/sick';
 import { isNotEmptyArray } from '@src/utils/arrayUtils';
+import { splitTargetRegardlessOfStringCase } from '@src/utils/stringUtils';
 import * as S from './styled';
 
 type Props = {
-	items: Sick[];
+	sickKeyword: string;
+	recommendSicks: Sick[];
 };
 
 const SickSearchAutoComplete = (props: Props) => {
 	return (
-		<S.Container>
-			{isNotEmptyArray(props.items) ? (
-				<>
+		<>
+			{props.sickKeyword && isNotEmptyArray(props.recommendSicks) && (
+				<S.Container>
 					<S.Caption>추천 검색어</S.Caption>
-					{props.items.map((item) => {
-						return <S.AutoCompleteItemWrapper key={item.sickCd}>🔍 {item.sickNm}</S.AutoCompleteItemWrapper>;
+					{props.recommendSicks.map((recommendSick) => {
+						return (
+							<S.AutoCompleteItemWrapper key={recommendSick.sickCd}>
+								🔍
+								<S.TextWrapper>
+									{splitTargetRegardlessOfStringCase(recommendSick.sickNm, props.sickKeyword).map(
+										(splitedItem, index, splitedItems) => {
+											if (splitedItems.length - 1 === index) {
+												return <React.Fragment key={index}>{splitedItem}</React.Fragment>;
+											}
+											return (
+												<React.Fragment key={index}>
+													{splitedItem}
+													<S.HightLightText>{props.sickKeyword.toUpperCase()}</S.HightLightText>
+												</React.Fragment>
+											);
+										},
+									)}
+								</S.TextWrapper>
+							</S.AutoCompleteItemWrapper>
+						);
 					})}
-				</>
-			) : (
-				<S.AutoCompleteItemWrapper>🔍 추천 검색어 존재하지 않습니다.</S.AutoCompleteItemWrapper>
+				</S.Container>
 			)}
-		</S.Container>
+		</>
 	);
 };
 

--- a/src/components/feature/SickSearch/SickSearchAutoComplete/styled.ts
+++ b/src/components/feature/SickSearch/SickSearchAutoComplete/styled.ts
@@ -21,12 +21,27 @@ export const Caption = styled.span`
 `;
 
 export const AutoCompleteItemWrapper = styled.li`
-	display: flex;
+	display: block;
 	align-items: center;
+	width: 480px;
 	padding: 1em 1.5em;
+	line-height: 1.2;
 	cursor: pointer;
+
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	overflow: hidden;
 
 	&:hover {
 		background-color: ${({ theme }) => theme.colors.lightgray};
 	}
+`;
+
+export const TextWrapper = styled.span`
+	margin-left: 0.5rem;
+`;
+
+export const HightLightText = styled.strong`
+	font-weight: ${({ theme }) => theme.fontWeights.bold};
+	color: ${({ theme }) => theme.colors.primary};
 `;

--- a/src/components/feature/SickSearch/SickSearchAutoComplete/styled.ts
+++ b/src/components/feature/SickSearch/SickSearchAutoComplete/styled.ts
@@ -20,14 +20,14 @@ export const Caption = styled.span`
 	color: ${({ theme }) => theme.colors.lightgray};
 `;
 
-export const AutoCompleteItemWrapper = styled.li`
+export const AutoCompleteItemWrapper = styled.li<{ isFocused?: boolean }>`
 	display: block;
 	align-items: center;
 	width: 480px;
 	padding: 1em 1.5em;
+	background-color: ${({ isFocused, theme }) => isFocused && theme.colors.lightgray};
 	line-height: 1.2;
 	cursor: pointer;
-
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	overflow: hidden;

--- a/src/components/feature/SickSearch/SickSearchForm/index.tsx
+++ b/src/components/feature/SickSearch/SickSearchForm/index.tsx
@@ -5,20 +5,32 @@ type Props = {
 	sickKeyword: string;
 	onSickKeywordChange: (newSickKeyowrd: string) => void;
 	onSickKeywordReset: () => void;
+	onSickSearchInputKeydown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
 };
 
 const SickSearchForm = (props: Props) => {
-	const handleSickSearchInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+	const handleSickSearchInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {};
+
+	const handleSickSearchInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {};
+
+	const handleSickSearchInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		props.onSickKeywordChange(event.currentTarget.value);
 	};
 
+	const handleSickSearchFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+	};
+
 	return (
-		<S.SickSearchForm onSubmit={() => {}}>
+		<S.SickSearchForm onSubmit={handleSickSearchFormSubmit}>
 			<S.SickSearchInput
 				type="text"
 				placeholder="🔍 질환명을 입력해 주세요."
 				value={props.sickKeyword}
-				onChange={handleSickSearchInput}
+				onKeyDown={props.onSickSearchInputKeydown}
+				onFocus={handleSickSearchInputFocus}
+				onBlur={handleSickSearchInputBlur}
+				onChange={handleSickSearchInputChange}
 			/>
 			<S.SickSearchResetButton type="button" onClick={props.onSickKeywordReset}>
 				<img src={CloseIcon} alt="검색어 초기화" className="search-reset" />

--- a/src/components/feature/SickSearch/SickSearchForm/index.tsx
+++ b/src/components/feature/SickSearch/SickSearchForm/index.tsx
@@ -1,11 +1,26 @@
 import * as S from './styled';
 import { CloseIcon, SearchIcon } from '@src/assets/icons';
 
-const SickSearchForm = () => {
+type Props = {
+	sickKeyword: string;
+	onSickKeywordChange: (newSickKeyowrd: string) => void;
+	onSickKeywordReset: () => void;
+};
+
+const SickSearchForm = (props: Props) => {
+	const handleSickSearchInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+		props.onSickKeywordChange(event.currentTarget.value);
+	};
+
 	return (
 		<S.SickSearchForm onSubmit={() => {}}>
-			<S.SickSearchInput type="text" placeholder="🔍 질환명을 입력해 주세요." />
-			<S.SickSearchResetButton type="button">
+			<S.SickSearchInput
+				type="text"
+				placeholder="🔍 질환명을 입력해 주세요."
+				value={props.sickKeyword}
+				onChange={handleSickSearchInput}
+			/>
+			<S.SickSearchResetButton type="button" onClick={props.onSickKeywordReset}>
 				<img src={CloseIcon} alt="검색어 초기화" className="search-reset" />
 			</S.SickSearchResetButton>
 			<S.SickSearchButton type="submit">

--- a/src/components/feature/SickSearch/index.tsx
+++ b/src/components/feature/SickSearch/index.tsx
@@ -1,55 +1,32 @@
 import SickSearchForm from '@src/components/feature/SickSearch/SickSearchForm';
 import SickSearchAutoComplete from '@src/components/feature/SickSearch/SickSearchAutoComplete';
 import * as S from './styled';
-
-const dummys = [
-	{
-		sickCd: 'A00',
-		sickNm: '콜레라',
-	},
-	{
-		sickCd: 'A01',
-		sickNm: '장티푸스 및 파라티푸스',
-	},
-	{
-		sickCd: 'A02',
-		sickNm: '기타 살모넬라 감염',
-	},
-	{
-		sickCd: 'A03',
-		sickNm: '시겔라증',
-	},
-	{
-		sickCd: 'A04',
-		sickNm: '기타 세균성 장 감염',
-	},
-	{
-		sickCd: 'A05',
-		sickNm: '달리 분류되지 않는 기타 세균성 음식매개중독',
-	},
-	{
-		sickCd: 'A06',
-		sickNm: '아메바증',
-	},
-	{
-		sickCd: 'A07',
-		sickNm: '기타 원충성 장 질환',
-	},
-	{
-		sickCd: 'A08',
-		sickNm: '바이러스 및 기타 명시된 장 감염',
-	},
-	{
-		sickCd: 'A09',
-		sickNm: '감염성 및 상세불명 기원의 기타 위장염 및 결장염',
-	},
-];
+import { useState } from 'react';
+import { Sick } from '@src/types/sick';
+import { getSicksByIncludeKeyword } from '@src/core/apis/sick';
 
 const SickSearch = () => {
+	const [sickKeyword, setSickKeyword] = useState('');
+	const [recommendSicks, setRecommendSicks] = useState<Sick[]>([]);
+
+	const handleSickKeywordChange = async (newSickKeyword: string) => {
+		const newRecommendSicks = await getSicksByIncludeKeyword(newSickKeyword);
+		setRecommendSicks(newRecommendSicks);
+		setSickKeyword(newSickKeyword);
+	};
+
+	const handleSickKeywordReset = () => {
+		setSickKeyword('');
+	};
+
 	return (
 		<S.Container>
-			<SickSearchForm />
-			<SickSearchAutoComplete items={dummys} />
+			<SickSearchForm
+				sickKeyword={sickKeyword}
+				onSickKeywordChange={handleSickKeywordChange}
+				onSickKeywordReset={handleSickKeywordReset}
+			/>
+			<SickSearchAutoComplete sickKeyword={sickKeyword} recommendSicks={recommendSicks} />
 		</S.Container>
 	);
 };

--- a/src/components/feature/SickSearch/index.tsx
+++ b/src/components/feature/SickSearch/index.tsx
@@ -10,9 +10,9 @@ const SickSearch = () => {
 	const [recommendSicks, setRecommendSicks] = useState<Sick[]>([]);
 
 	const handleSickKeywordChange = async (newSickKeyword: string) => {
+		setSickKeyword(newSickKeyword);
 		const newRecommendSicks = await getSicksByIncludeKeyword(newSickKeyword);
 		setRecommendSicks(newRecommendSicks);
-		setSickKeyword(newSickKeyword);
 	};
 
 	const handleSickKeywordReset = () => {

--- a/src/components/feature/SickSearch/index.tsx
+++ b/src/components/feature/SickSearch/index.tsx
@@ -1,9 +1,17 @@
 import SickSearchForm from '@src/components/feature/SickSearch/SickSearchForm';
 import SickSearchAutoComplete from '@src/components/feature/SickSearch/SickSearchAutoComplete';
 import * as S from './styled';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Sick } from '@src/types/sick';
 import { getSicksByIncludeKeyword } from '@src/core/apis/sick';
+import { isNotEmptyArray } from '@src/utils/arrayUtils';
+
+const autoCompleteTargetKeys = {
+	ARROW_UP: 'ArrowUp',
+	ARROW_DOWN: 'ArrowDown',
+	ESCAPE: 'Escape',
+	BACK_SPACE: 'Backspace',
+} as const;
 
 const SickSearch = () => {
 	const [sickKeyword, setSickKeyword] = useState('');
@@ -19,14 +27,55 @@ const SickSearch = () => {
 		setSickKeyword('');
 	};
 
+	const [currentAutoCompleteIndex, setCurrentAutoCompleteIndex] = useState(-1);
+	const autoCompleteRef = useRef<HTMLUListElement>(null) as React.MutableRefObject<HTMLUListElement>;
+
+	const handleSickSearchInputKeydown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+		if (!isNotEmptyArray(recommendSicks) || !autoCompleteRef) {
+			setCurrentAutoCompleteIndex(-1);
+			return;
+		}
+
+		switch (event.key) {
+			case autoCompleteTargetKeys.ARROW_DOWN:
+				if (currentAutoCompleteIndex + 1 === autoCompleteRef?.current?.childElementCount - 2) {
+					setCurrentAutoCompleteIndex(-1);
+					break;
+				}
+				setCurrentAutoCompleteIndex(currentAutoCompleteIndex + 1);
+				break;
+			case autoCompleteTargetKeys.ARROW_UP:
+				if (currentAutoCompleteIndex - 1 < -1) {
+					setCurrentAutoCompleteIndex(autoCompleteRef?.current?.childElementCount - 3);
+					break;
+				}
+				setCurrentAutoCompleteIndex(currentAutoCompleteIndex - 1);
+				break;
+			case autoCompleteTargetKeys.BACK_SPACE:
+				setCurrentAutoCompleteIndex(-1);
+				break;
+			case autoCompleteTargetKeys.ESCAPE:
+				setCurrentAutoCompleteIndex(-1);
+				break;
+			default:
+				break;
+		}
+	};
+
 	return (
 		<S.Container>
 			<SickSearchForm
 				sickKeyword={sickKeyword}
 				onSickKeywordChange={handleSickKeywordChange}
 				onSickKeywordReset={handleSickKeywordReset}
+				onSickSearchInputKeydown={handleSickSearchInputKeydown}
 			/>
-			<SickSearchAutoComplete sickKeyword={sickKeyword} recommendSicks={recommendSicks} />
+			<SickSearchAutoComplete
+				sickKeyword={sickKeyword}
+				recommendSicks={recommendSicks}
+				currentAutoCompleteIndex={currentAutoCompleteIndex}
+				autoCompleteRef={autoCompleteRef}
+			/>
 		</S.Container>
 	);
 };

--- a/src/core/apis/sick.ts
+++ b/src/core/apis/sick.ts
@@ -2,7 +2,7 @@ import { API_PATH, HttpMethod } from '@src/core/apis/common';
 import requester from '@src/core/apis/requester';
 import { Sick } from '@src/types/sick';
 
-export const getSicksByIncludeKeyword = async (keyword: string) => {
+export const getSicksByIncludeKeyword = async (keyword: string, sliceCount: number = 8) => {
 	console.info('calling api');
 
 	const {
@@ -14,5 +14,5 @@ export const getSicksByIncludeKeyword = async (keyword: string) => {
 		url: `${index}?sickNm_like=${keyword}`,
 	});
 
-	return sicks;
+	return sicks.slice(0, sliceCount);
 };

--- a/src/core/apis/sick.ts
+++ b/src/core/apis/sick.ts
@@ -2,15 +2,17 @@ import { API_PATH, HttpMethod } from '@src/core/apis/common';
 import requester from '@src/core/apis/requester';
 import { Sick } from '@src/types/sick';
 
-export const getSick = async () => {
+export const getSicksByIncludeKeyword = async (keyword: string) => {
+	console.info('calling api');
+
 	const {
 		sick: { index },
 	} = API_PATH;
 
-	const { payload } = await requester<Sick[]>({
+	const { payload: sicks } = await requester<Sick[]>({
 		method: HttpMethod.GET,
-		url: index,
+		url: `${index}?sickNm_like=${keyword}`,
 	});
 
-	return payload;
+	return sicks;
 };

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,0 +1,6 @@
+export const splitTargetRegardlessOfStringCase = (target: string, keyword: string) => {
+	const splitedByUpperCase = target.split(keyword.toUpperCase());
+	const splitedByLowerCase = target.split(keyword.toLowerCase());
+
+	return splitedByLowerCase.length > splitedByUpperCase.length ? splitedByLowerCase : splitedByUpperCase;
+};


### PR DESCRIPTION
## 해결한 이슈

- #6 

<br />

## 해결 방법

### 검색 키워드 입력에 따른 추천 검색어 자동 완성 기능

+ 키워드 검색 input 요소에 onChange 이벤트가 발생할 때마다, 새로운 키워드 데이터로 `sickKeyword` 상태를 변경합니다. 또한 새로운 키워드를 인자로 받는 `handleSetRecommendSicks` 함수가 실행되고, 이 시점에서 추천 검색어 데이터 GET 요청이 발생합니다. 

```tsx
const [sickKeyword, setSickKeyword] = useState('');  // 현재 키워드 
const [recommendSicks, setRecommendSicks] = useState<Sick[]>([]);  // 자동완성 리스트 데이터

const handleSickKeywordChange = async (newSickKeyword: string) => {
		...

		setSickKeyword(newSickKeyword);

		if (newSickKeyword) {
			...

			handleSetRecommendSicks(newSickKeyword);
		}
	};

const handleSetRecommendSicks = async (newSickKeyword: string) => {
	const newRecommendSicks = await getSicksByIncludeKeyword(newSickKeyword);
	setRecommendSicks(newRecommendSicks);
}

```

+ 추천 검색어 데이터 GET 요청 함수는, `필터링 키워드(string)` 를 필수로 받으며, 응답 받은 데이터에서 몇 개만 반환할지 정의하는 `sliceCount` 를 옵셔널하게 전달 받습니다.  추천 검색어 데이터가 많을 경우와 UI 표현상 간략화하기 위해 `sliceCount` 파리미터는 default value 로 8개의 데이터만 slice 해서 데이터를 반환하도록 구현되었습니다. 또한 API 호출 횟수를 확인하기 위해 해당 함수 내부에서 console.info 를 출력합니다. 

```ts
//  src/cors/apis/sick.ts

export const getSicksByIncludeKeyword = async (keyword: string, sliceCount: number = 8) => {
	console.info('calling api');

	const {
		sick: { index },
	} = API_PATH;

	const { payload: sicks } = await requester<Sick[]>({
		method: HttpMethod.GET,
		url: `${index}?sickNm_like=${keyword}`,
	});

	return sicks.slice(0, sliceCount);
};
```

### 검색한 키워드와 일치하는 추천 검색어 내 단어 볼드 처리

+ `splitTargetRegardlessOfStringCase` 라는 유틸 함수는 타겟 문자열과 그를 split 할 구분자(seperator)를 인자로 받습니다. 실제 데이터는 대소문자가 구분되지 않고 split 이 되어야합니다. 그렇지 않으면, 예를 들어 `B형 간염` 같은 키워드지만 입력 요소에 'b' 라고 입력할 경우 정상적인 연산이 되지 않을 것입니다.
이에 대한 처리를 `정규 표현식` 을 이용해서 처리한 다른 조들도 있었지만 문자열 메서드를 이용해서 처리할 수 있는 방법이 없을까 생각해서 이 방식을 채택하게 되었습니다. 대소문자는 한글보단 영문일 때 신경을 써야하는 부분입니다. 질환명의 특성상 보통 `대문자` 를 차용하므로 렌더링 시 seperator 에 대해 toUpperCase 를 적용한 결과를 렌더링 하도록 구현했습니다.

```ts
export const splitTargetRegardlessOfStringCase = (target: string, keyword: string) => {
  const splitedByUpperCase = target.toUpperCase().split(keyword.toUpperCase());
  const splitedByLowerCase = target.toLowerCase().split(keyword.toLowerCase());

  return splitedByLowerCase.length > splitedByUpperCase.length ? splitedByLowerCase : splitedByUpperCase;
};

+ 각 현재 추천 검색어 단어마다 `splitTargetRegardlessOfStringCase` 의 실행 결과로 분리된 문자열 배열(seperator, 즉 현재 입력 검색어는 제외된)` 이 반환되고, 이에 대해 map 함수를 돌면서 마지막 배열 데이터를 제외하고는 `(현재 map 요소), (seperator)` 세트로 렌더링하고, 마지막 map 요소에 대해서는 해당 요소만 렌더링 되도록 구현했습니다. 이렇게 생각한 이유는 seperator 로 split 된 결과는 항상 `split 된 배열 요소의 개수 === 분리된 횟수 + 1` 이 성립하기 때문입니다. 

``` 


### 추천 검색어 키보드로 이동 기능

- 내용을 입력해주세요.

<br />

## 캡처 첨부

### 키워드 검색어에 따른 질환명 자동완성

![autocomplete](https://user-images.githubusercontent.com/50790145/201064700-239799bb-89d6-4aef-94bb-7804d2470a00.gif)


### 키워드 검색어에 해당하는 텍스트 Bold 처리

![split_bold](https://user-images.githubusercontent.com/50790145/201189951-6c00277f-fd6e-4a0f-8ec3-ff1fe5559eeb.gif)


### 질환명 자동완성 리스트 내 키보드 이동 및 선택된 아이템 배경 하이라이트

> 키보드 이동은 `구글 검색창 작동 방식을 모티브로 구현`

+ 구글 검색어 자동완성 키보드 이동 형태

![google_autocomplete](https://user-images.githubusercontent.com/50790145/201188131-8fec5dee-fef0-4073-a83f-1b249e0ab052.gif)

+ 구현물 키보드 이동 형태

![autocomplete_keyboard](https://user-images.githubusercontent.com/50790145/201093613-68f7f599-44ac-4612-ab5d-7d14e3e7c7f2.gif)




<br />

## 추가적인 태스크

- [x] 연속적인 입력 이벤트에 대한 디바운싱(Debouncing) 처리
- [x] API 로컬 캐싱

<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
