### PR TITLE
[#12] 배경색 변경 & 자동완성 기능 개선

### DIFF
--- a/src/components/feature/Header/index.tsx
+++ b/src/components/feature/Header/index.tsx
@@ -1,10 +1,10 @@
-import { Layout, Navigation, Typography } from '@src/components';
+import { Navigation, Typography } from '@src/components';
 import * as S from './styled';
 import { SymbolImage } from '@src/assets/images';
 
 const Header = () => {
 	return (
-		<Layout>
+		<S.Container>
 			<S.Header>
 				<Typography variant="h1">
 					<S.LinkLogo to="/">
@@ -14,7 +14,7 @@ const Header = () => {
 				</Typography>
 				<Navigation />
 			</S.Header>
-		</Layout>
+		</S.Container>
 	);
 };
 

--- a/src/components/feature/Header/styled.ts
+++ b/src/components/feature/Header/styled.ts
@@ -1,12 +1,19 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
+export const Container = styled.div`
+	background-color: ${({ theme }) => theme.colors.white};
+`;
+
 export const Header = styled.header`
 	position: relative;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	max-width: ${({ theme }) => theme.maxWidth};
 	height: 56px;
+	margin: 0 auto;
+	padding: 0 20px;
 `;
 
 export const LinkLogo = styled(Link)`

--- a/src/components/feature/SickSearch/SickSearchAutoComplete/styled.ts
+++ b/src/components/feature/SickSearch/SickSearchAutoComplete/styled.ts
@@ -7,11 +7,13 @@ export const Container = styled.ul<{ isShow: boolean }>`
 	display: flex;
 	flex-direction: column;
 	width: 480px;
+	max-height: 480px;
 	padding: 1.5em 0;
 	border-radius: 2em;
 	background-color: ${({ theme }) => theme.colors.white};
 	-webkit-box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.2);
 	box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.2);
+	overflow-y: scroll;
 	opacity: ${({ isShow }) => (isShow ? 1 : 0)};
 `;
 

--- a/src/components/feature/SickSearch/index.tsx
+++ b/src/components/feature/SickSearch/index.tsx
@@ -1,7 +1,7 @@
 import SickSearchForm from '@src/components/feature/SickSearch/SickSearchForm';
 import SickSearchAutoComplete from '@src/components/feature/SickSearch/SickSearchAutoComplete';
 import * as S from './styled';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Sick } from '@src/types/sick';
 import { getSicksByIncludeKeyword } from '@src/core/apis/sick';
 import { isNotEmptyArray } from '@src/utils/arrayUtils';
@@ -17,7 +17,6 @@ const autoCompleteTargetKeys = {
 
 const SickSearch = () => {
 	const sickInCache = useMemo(() => new InMemoryCache(), []);
-
 	const [sickKeyword, setSickKeyword] = useState('');
 	const [recommendSicks, setRecommendSicks] = useState<Sick[]>([]);
 
@@ -71,6 +70,7 @@ const SickSearch = () => {
 		switch (event.key) {
 			case autoCompleteTargetKeys.ARROW_DOWN:
 				event.preventDefault();
+
 				if (currentAutoCompleteIndex + 1 === autoCompleteRef?.current?.childElementCount - 2) {
 					setCurrentAutoCompleteIndex(-1);
 					break;
@@ -79,6 +79,7 @@ const SickSearch = () => {
 				break;
 			case autoCompleteTargetKeys.ARROW_UP:
 				event.preventDefault();
+
 				if (currentAutoCompleteIndex - 1 < -1) {
 					setCurrentAutoCompleteIndex(autoCompleteRef?.current?.childElementCount - 3);
 					break;
@@ -92,6 +93,19 @@ const SickSearch = () => {
 				break;
 		}
 	};
+
+	const handleSearchKeywordChangeByKeydown = () => {
+		const currentFocusedAutoCompleteItem = autoCompleteRef?.current?.getElementsByTagName('li')[currentAutoCompleteIndex + 1];
+		if (!currentFocusedAutoCompleteItem) return;
+
+		if (currentFocusedAutoCompleteItem.textContent) {
+			setSickKeyword(currentFocusedAutoCompleteItem.textContent?.slice(2));
+		}
+	};
+
+	useEffect(() => {
+		handleSearchKeywordChangeByKeydown();
+	}, [currentAutoCompleteIndex]);
 
 	const [isSickSearchFormFocused, setIsSickSearchFormFocused] = useState(false);
 

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -9,7 +9,7 @@ const NotFound = () => {
 		<div>
 			<Header />
 			<S.InnerContainer>
-				<p className="error-message-default">존재하지 않는 페이지입니다.</p>
+				<p className="error-message-default">존재하지 않는 페이지입니다. 🤪</p>
 				<p className="error-message-url">{`URL: ${location.protocol}//${location.hostname}:${location.port}${locator.pathname}`}</p>
 			</S.InnerContainer>
 		</div>

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -12,6 +12,7 @@ const GlobalStyle = styled.createGlobalStyle`
 
 	body {
 		font-size: 16px;
+		background-color: ${({ theme }) => theme.colors.sky};
 	}
 
 	ul,


### PR DESCRIPTION
## 해결한 이슈

- #12 

<br />

## 해결 방법

`전체 배경, 헤더 배경 적용`

+ `GlobalStyle` 에 body 에 background-color 를 sky 적용
+ 헤더는 `max-width` 가 적용된 Layout 컴포넌트가 컨테이너로 감싸고 있었는데, 창 크기가 커졌을 때 전체 너비만큼 배경이 적용되질 않음, 따라서 Layout 컴포넌트 컨테이너를 제거, 일반 div 컨테이너를 적용하고 내부 header 요소에 `max-width` 값과 `margin: 0 auto` 를 주어 가운데 정렬

```ts
//  src/styles/GlobalStyle.ts

...

const GlobalStyle = styled.createGlobalStyle`
	...

	body {
		...
		background-color: ${({ theme }) => theme.colors.sky};  // Custom Theme 에 있는 Sky 색상
	}

	...
`;

export default GlobalStyle;
```

`자동완성 기능 개선 - 현재 포커싱된 아이템 텍스트를 현재 검색중인 키워드로 반영`

(자동완성 리스트가 있다는 전제하에) Keydown 이벤트로 인해 `currentAutoCompleteIndex` 상태값이 변경될 때마다 useEffect 훅이 작동하면서 내부에서는 `handleSearchKeywordChangeByKeydown` 함수가 작동

```tsx
// src/components/feature/SickSearch/index.tsx

...
const handleSearchKeywordChangeByKeydown = () => {
	const currentFocusedAutoCompleteItem = autoCompleteRef?.current?.getElementsByTagName('li')[currentAutoCompleteIndex + 1];
	if (!currentFocusedAutoCompleteItem) return;

	if (currentFocusedAutoCompleteItem.textContent) {
		setSickKeyword(currentFocusedAutoCompleteItem.textContent?.slice(2));
	}
};

...
```

+ `handleSearchKeywordChangeByKeydown` 함수는 현재 포커싱된 아이템(들)(`HTMLLIElement`) 중에서 현재 포커싱된 `HTMLLIElement` 을 얻어내고, 해당 요소의 textContent 를 알아내서 현재 검색어 키워드로 `setSickKeyword` 합니다.

+ 실질적인 HTMLLIElement 가 있는 순서가 N 번째라면, 우리는 N + 1 번째 요소를 선택하는데, 이유는 첫 번째 HTMLLIElement 요소는 실제 추천 검색어 아이템에 대한 HTMLLIElement 가 아닌, 현재 검색 중인 텍스트에 대한 HTMLLIElement 이고, 해당 요소는 실질적인 전체 HTMLLIElement 요소 개수에서 제외해야하기 때문입니다.

+ 찾은 HTMLLIElement 에 대한 textContents 문자열 데이터에서 `타겟문자열.slice(2)` 를 하는 이유는 첫번째 `돋보기(🔍)` 와 `띄어쓰기(' ')` 를 포함시키지 않기 위해서입니다.



<br />

## 캡처 첨부

`배경색 변경 & 자동 완성 이동 기능 개선 작업 이후`

![refactor](https://user-images.githubusercontent.com/50790145/201287207-8055b514-2188-4024-abf2-1c9004bde137.gif)

